### PR TITLE
Agent parameter for mojang.auth() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Authenticate
  - `username`: (String) email or uesrname of the Mojang account.
  - `password`: (String) password of the Mojang account.
  - `clientToken` (String) optional clientToken.
+ - `authAgent` (Object) agent object containing a *name* and a *version* property
 
 ```javascript
 mojang.auth('foo', 'bar', 'baz').then(...);

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -2,7 +2,7 @@
 
 const request = require('./_request');
 
-function auth(username, password, clientToken) {
+function auth(username, password, clientToken, appAgent) {
   return request({
     method: 'POST',
     hostname: 'authserver.mojang.com',
@@ -11,6 +11,7 @@ function auth(username, password, clientToken) {
     username: username,
     password: password,
     clientToken: clientToken,
+    agent: appAgent
   });
 }
 


### PR DESCRIPTION
The Mojang API returns some really handy information when authenticating with your Mojang credentials. However _selectedProfile_ and _availableProfiles_ are only going to show up if the request contained an agent field.
```
"agent": {
  "name": "Minecraft",
  "version": 1
}
```
See [wiki](http://wiki.vg/Authentication)
